### PR TITLE
Fixed an error that causes a null value to be added as the first value in the history.states array

### DIFF
--- a/commonwealth.js
+++ b/commonwealth.js
@@ -56,8 +56,15 @@ commonwealth.Stateful = function Stateful (options) {
             if (oldState && _.isFunction(oldState["exit"])) {
                 oldState.exit();
             }
+
+            // Fixed an error where oldState (with value null) was being
+            // pushed to the history.states array
             if (this.history) {
-                this.history.addState(oldState);
+                if(oldState === null) {
+                    this.history.addState(state);
+                } else {
+                    this.history.addState(oldState);
+                }
             }
             currentState = newState;
 


### PR DESCRIPTION
When executing setCurrentState(stateObj) for the first time, the value of oldState is pushed to the history.states array with a value of null. This change checks the oldState variable for a null value before pushing it onto the history.states array and if it is null, it instead pushes the state object passed to setCurrentState().
![Screen Shot 2013-02-25 at 11 45 35 PM](https://f.cloud.github.com/assets/933567/195319/8d7a23d8-7fe8-11e2-8af9-9e9fdfdfc5ed.JPG)
